### PR TITLE
Add udp and ports specification for openvpn.sh

### DIFF
--- a/check_vpn/check_vpn_plugins/openvpn.sh
+++ b/check_vpn/check_vpn_plugins/openvpn.sh
@@ -21,7 +21,7 @@
 ###########
 [ x"$OPENVPN_DEVICE_PREFIX" = x ] && declare -r OPENVPN_DEVICE_PREFIX=tun
 [ x"$OPENVPN_PORT" = x ] && declare -i -r OPENVPN_PORT=1194
-[ x"$OPENVPN_PROTOCOL" = x ] && declare -i -r OPENVPN_PROTOCOL=tcp
+[ x"$OPENVPN_PROTOCOL" = x ] && declare -r OPENVPN_PROTOCOL=tcp
 
 # returns a free vpn device
 _openvpn_allocate_vpn_device() {
@@ -60,7 +60,7 @@ _openvpn_start_vpn() {
 		return 1
 	fi
 
-	if [ $OPENVPN_PROTOCOL -eq 'tcp' ]; then
+	if [ $OPENVPN_PROTOCOL == 'tcp' ]; then
 		check_open_port $lns $OPENVPN_PORT
 		if [ $? -ne 0 ]; then
 			ERROR_STRING="Port '$OPENVPN_PORT' closed on '$lns'"


### PR DESCRIPTION
Hello,                                                                                                                                                         

I need to use check_vpn with an openvpn server in udp and a specific port. So I made some modification on check_vpn_plugins/openvpn.sh                         
- no nmap check if udp (the port seem already open, even if its close, nmap -Pn -sU -p 20000 google.com | grep -q "20000/udp open" will be open true)  
- --connect-retry is a tcp only args, so I moved it on a protocol_extra_args vars.                                                                            
  
  To use this, you need to exec :                                                                                                                               
  
  OPENVPN_PORT=443 OPENVPN_PROTOCOL=udp ./check_vpn -t openvpn -H  you_server.com -u user -p password -- extra_args                                             
  
  Hope this script will be helpfull for another people                                                                                                          
  
  Nico
