### PR TITLE
check_vpn: using nc for port testing

### DIFF
--- a/check_vpn/check_vpn
+++ b/check_vpn/check_vpn
@@ -109,7 +109,7 @@ wait_for_vpn_to_come_down() {
 check_open_port() {
 	local host=$1; shift
 	local -i port=$1; shift
-	echo -n "" | nc -w 5 $host $port >& /dev/null
+	echo | nc -w 5 $host $port >& /dev/null
 }
 
 # returns routing table number for device


### PR DESCRIPTION
On some installations, using nmap will not be possible to probe for open ports (either not installed or version too old), using nc should mitigate some of the pain.
