### PR TITLE
Use tun as default device type for openvpn

### DIFF
--- a/check_vpn/check_vpn_plugins/openvpn.sh
+++ b/check_vpn/check_vpn_plugins/openvpn.sh
@@ -26,6 +26,9 @@ declare -i -r OPENVPN_PORT=1194
 # $1 - device prefix
 _openvpn_allocate_vpn_device() {
 	local device_prefix=$1; shift
+	if [ x"$device_prefix" = x ]; then
+		device_prefix=$OPENVPN_DEVICE_PREFIX
+	fi
 	allocate_vpn_device $device_prefix
 }
 


### PR DESCRIPTION
Fixes #18 

When no device type is selected for OpenVPN - use `tun` be default.